### PR TITLE
New-HTMLTab - Add Text-Transform

### DIFF
--- a/Public/New-HTMLTab.ps1
+++ b/Public/New-HTMLTab.ps1
@@ -68,7 +68,8 @@ function New-HTMLTab {
         [parameter(ParameterSetName = "FontAwesomeSolid")][int] $IconSize,
         [parameter(ParameterSetName = "FontAwesomeBrands")]
         [parameter(ParameterSetName = "FontAwesomeRegular")]
-        [parameter(ParameterSetName = "FontAwesomeSolid")][string] $IconColor
+        [parameter(ParameterSetName = "FontAwesomeSolid")][string] $IconColor,
+        [ValidateSet('uppercase', 'lowercase', 'capitalize')][string] $TextTransform  # New-HTMLTab - Add text-transform
     )
     if (-not $Script:HTMLSchema.Features) {
         Write-Warning 'New-HTMLTab - Creation of HTML aborted. Most likely New-HTML is missing.'
@@ -90,6 +91,14 @@ function New-HTMLTab {
     if ($TextColor) {
         $StyleText.'color' = ConvertFrom-Color -Color $TextColor
     }
+    # New-HTMLTab - Add text-transform
+    if($TextTransform){
+        $StyleText.'text-transform' = "$TextTransform"
+    }
+    else{
+        $StyleText.'text-transform' = "uppercase"
+    }
+    # end
 
     $StyleIcon = @{ }
     if ($IconSize -ne 0) {


### PR DESCRIPTION
Add text-transform style option for the New-HTMLTab, to allow text in the tab to be uppercase, lowercase or capitalized.